### PR TITLE
feat: egg style && upgrade to 2

### DIFF
--- a/server/.autod.conf.js
+++ b/server/.autod.conf.js
@@ -3,6 +3,7 @@
 module.exports = {
   write: true,
   prefix: '^',
+  plugin: 'autod-egg',
   test: [
     'test',
     'benchmark',
@@ -14,8 +15,8 @@ module.exports = {
     'egg-bin',
     'autod',
     'eslint',
-    'eslint-config-egg',
     'supertest',
+    'autod-egg',
     'webstorm-disable-index',
   ],
   exclude: [

--- a/server/app/controller/api.js
+++ b/server/app/controller/api.js
@@ -43,7 +43,7 @@ module.exports = app => {
         }
       }
       const resources = yield this.service.api.getRichList(condition, page, limit, order)
-      const count = yield app.model.api.find(condition).count().exec()
+      const count = yield app.model.Api.find(condition).count().exec()
       this.ctx.body = { resources, pages: { limit, page, count } }
       this.ctx.status = 200
     }
@@ -114,7 +114,7 @@ module.exports = app => {
       assert(mongoose.Types.ObjectId.isValid(groupId), 403, 'invalid groupId')
       assert(mongoose.Types.ObjectId.isValid(apiId), 403, 'invalid apiId')
 
-      const resources = (yield app.model.api.findOne({ _id: apiId, isDeleted: false })).toObject()
+      const resources = (yield app.model.Api.findOne({ _id: apiId, isDeleted: false })).toObject()
       resources.history = yield this.service.apiHistory.get(resources)
 
       this.ctx.body = { resources }
@@ -194,7 +194,7 @@ module.exports = app => {
           msg: '无权删除'
         })
       }
-      yield app.model.group.update({ _id: groupId }, { modifiedTime: Date.now() }, { new: true }).exec()
+      yield app.model.Group.update({ _id: groupId }, { modifiedTime: Date.now() }, { new: true }).exec()
       this.ctx.logger.info('deleteApi')
       this.ctx.status = 204
     }

--- a/server/app/controller/authority.js
+++ b/server/app/controller/authority.js
@@ -19,7 +19,7 @@ module.exports = app => {
     }
     * getApi () {
       const { apiId } = this.ctx.params
-      const authority = (yield this.service.apiAuthority.get(apiId)) || app.model.apiAuthority()
+      const authority = (yield this.service.apiAuthority.get(apiId)) || app.model.ApiAuthority()
       authority.apiId = apiId
       this.success(authority)
     }

--- a/server/app/controller/client.js
+++ b/server/app/controller/client.js
@@ -10,9 +10,9 @@ module.exports = app => {
       if (id.length < 5) {
         // hack方法，兼容老的存下url信息的api
         const url = `/client/${id}`
-        return yield app.model.api.findOne({ url, 'options.method': method }).exec()
+        return yield app.model.Api.findOne({ url, 'options.method': method }).exec()
       }
-      return yield app.model.api.findOne({ _id: id, 'options.method': method }).exec()
+      return yield app.model.Api.findOne({ _id: id, 'options.method': method }).exec()
     }
     * real () {
       const { _apiRealUrl, _apiMethod } = this.ctx.request.body

--- a/server/app/controller/group.js
+++ b/server/app/controller/group.js
@@ -27,13 +27,13 @@ module.exports = app => {
         isDeleted: false,
         name: reg
       }
-      const resources = yield app.model.group
-                                       .find(cond)
-                                       .sort({ modifiedTime: -1, createTime: -1 })
-                                       .skip((page - 1) * limit)
-                                       .limit(limit)
-                                       .exec()
-      const count = yield app.model.group.find(cond).count().exec()
+      const resources = yield app.model.Group
+        .find(cond)
+        .sort({ modifiedTime: -1, createTime: -1 })
+        .skip((page - 1) * limit)
+        .limit(limit)
+        .exec()
+      const count = yield app.model.Group.find(cond).count().exec()
       this.ctx.body = { resources, pages: { limit, page, count } }
       this.ctx.status = 200
     }

--- a/server/app/model/api.js
+++ b/server/app/model/api.js
@@ -1,4 +1,5 @@
-module.exports = mongoose => {
+module.exports = app => {
+  const mongoose = app.mongoose
   const { ObjectId } = mongoose.Schema.Types
   const ApiSchema = mongoose.Schema({
     group: {

--- a/server/app/model/api_authority.js
+++ b/server/app/model/api_authority.js
@@ -1,4 +1,5 @@
-module.exports = mongoose => {
+module.exports = app => {
+  const mongoose = app.mongoose
   const { ObjectId } = mongoose.Schema.Types
   const ApiAuthoritySchema = mongoose.Schema({
     apiId: {
@@ -9,7 +10,7 @@ module.exports = mongoose => {
     operation: { // 编辑权限
       mode: {
         type: Number,
-        default: 0  // 0 - 所有人, 1 - 组内人员 2 - 指定人员
+        default: 0 // 0 - 所有人, 1 - 组内人员 2 - 指定人员
       },
       operator: {
         type: [ ObjectId ],

--- a/server/app/model/api_history.js
+++ b/server/app/model/api_history.js
@@ -1,4 +1,5 @@
-module.exports = mongoose => {
+module.exports = app => {
+  const mongoose = app.mongoose
   const { ObjectId } = mongoose.Schema.Types
   const ApiHistorySchema = mongoose.Schema({
     apiId: {

--- a/server/app/model/api_stat.js
+++ b/server/app/model/api_stat.js
@@ -1,5 +1,6 @@
 const moment = require('moment')
-module.exports = mongoose => {
+module.exports = app => {
+  const mongoose = app.mongoose
   const { ObjectId } = mongoose.Schema.Types
   const ApiStatSchema = mongoose.Schema({
     apiId: {

--- a/server/app/model/group.js
+++ b/server/app/model/group.js
@@ -1,4 +1,5 @@
-module.exports = mongoose => {
+module.exports = app => {
+  const mongoose = app.mongoose
   const { ObjectId } = mongoose.Schema.Types
   const GroupSchema = new mongoose.Schema({
     teamId: {

--- a/server/app/model/team.js
+++ b/server/app/model/team.js
@@ -1,7 +1,8 @@
 /**
  * 团队；目前无用，可设计为分组的外层
  */
-module.exports = mongoose => {
+module.exports = app => {
+  const mongoose = app.mongoose
   const { ObjectId } = mongoose.Schema.Types
   const TeamSchema = new mongoose.Schema({
     name: {

--- a/server/app/model/user.js
+++ b/server/app/model/user.js
@@ -1,4 +1,5 @@
-module.exports = mongoose => {
+module.exports = app => {
+  const mongoose = app.mongoose
   const { ObjectId } = mongoose.Schema.Types
   const UserSchema = new mongoose.Schema({
     email: {

--- a/server/app/service/api.js
+++ b/server/app/service/api.js
@@ -1,7 +1,7 @@
 module.exports = app => {
   class Api extends app.Service {
     getById (apiId) {
-      return app.model.api.findOne({
+      return app.model.Api.findOne({
         _id: apiId,
         isDeleted: false
       })
@@ -14,29 +14,29 @@ module.exports = app => {
         api.follower = [ authId ]
         return api
       })
-      return app.model.api.insertMany(apis)
+      return app.model.Api.insertMany(apis)
     }
     create (api) {
       const authId = this.ctx.authUser._id
       api.creator = authId
       api.manager = authId
       api.follower = [ authId ]
-      return app.model.api(api).save()
+      return app.model.Api(api).save()
     }
     update (apiId, api) {
       api.modifiedTime = Date.now()
-      return app.model.api.findOneAndUpdate({
+      return app.model.Api.findOneAndUpdate({
         _id: apiId
       }, api, { new: true })
     }
     * isManager (apiId) {
-      return !!(yield app.model.api.findOne({
+      return !!(yield app.model.Api.findOne({
         _id: apiId,
         manager: this.ctx.authUser._id
       }))
     }
     delete (apiId) {
-      return app.model.api.findOneAndUpdate({
+      return app.model.Api.findOneAndUpdate({
         _id: apiId,
         manager: this.ctx.authUser._id
       }, {
@@ -45,7 +45,7 @@ module.exports = app => {
       })
     }
     deleteGroupApis (groupId) {
-      return app.model.api.update({
+      return app.model.Api.update({
         group: groupId
       }, {
         modifiedTime: Date.now(),
@@ -53,11 +53,11 @@ module.exports = app => {
       }, { multi: true })
     }
     getList (cond, page, limit, order = {}) {
-      return app.model.api
-                      .find(cond)
-                      .sort(Object.assign(order, { modifiedTime: -1, createTime: -1 }))
-                      .skip((page - 1) * limit)
-                      .limit(limit)
+      return app.model.Api
+        .find(cond)
+        .sort(Object.assign(order, { modifiedTime: -1, createTime: -1 }))
+        .skip((page - 1) * limit)
+        .limit(limit)
     }
     getManageList (page, limit) {
       const cond = {

--- a/server/app/service/api_authority.js
+++ b/server/app/service/api_authority.js
@@ -1,8 +1,8 @@
 const { authority } = require('../../constants')
 const {
-    OPERATION_ALL,
-    OPERATION_MEMBER,
-    OPERATION_DESIGNEE
+  OPERATION_ALL,
+  OPERATION_MEMBER,
+  OPERATION_DESIGNEE
 } = authority
 
 module.exports = app => {
@@ -10,7 +10,7 @@ module.exports = app => {
     update (apiId, authority) {
       authority = (typeof authority === 'object') ? authority : {}
       authority.modifiedTime = Date.now()
-      return app.model.apiAuthority.findOneAndUpdate({
+      return app.model.ApiAuthority.findOneAndUpdate({
         apiId
       }, authority, {
         setDefaultsOnInsert: true,
@@ -19,7 +19,7 @@ module.exports = app => {
       })
     }
     get (apiId) {
-      return app.model.apiAuthority.findOne({
+      return app.model.ApiAuthority.findOne({
         apiId
       })
     }

--- a/server/app/service/api_history.js
+++ b/server/app/service/api_history.js
@@ -1,12 +1,12 @@
 module.exports = app => {
   class ApiHistory extends app.Service {
     get (apiId) {
-      return app.model.apiHistory.findOne({
+      return app.model.ApiHistory.findOne({
         apiId
       })
     }
     create (api) {
-      return app.model.apiHistory({
+      return app.model.ApiHistory({
         apiId: api._id,
         data: api
       }).save()
@@ -18,7 +18,7 @@ module.exports = app => {
         operator: _id,
         operatorName: name
       }
-      return app.model.apiHistory.findOneAndUpdate({
+      return app.model.ApiHistory.findOneAndUpdate({
         apiId: api._id
       }, {
         updateTime: Date.now(),

--- a/server/app/service/group.js
+++ b/server/app/service/group.js
@@ -1,10 +1,10 @@
 const { authority } = require('../../constants')
 const {
-    PRIVACY_ALL,
-    PRIVACY_MEMBER,
-    PRIVACY_SELF,
-    OPERATION_ALL,
-    OPERATION_MEMBER
+  PRIVACY_ALL,
+  PRIVACY_MEMBER,
+  PRIVACY_SELF,
+  OPERATION_ALL,
+  OPERATION_MEMBER
 } = authority
 
 module.exports = app => {
@@ -38,17 +38,17 @@ module.exports = app => {
           manager: authId
         }]
       }
-      return app.model.group.find(cond).sort({ modifiedTime: -1, createTime: -1 })
+      return app.model.Group.find(cond).sort({ modifiedTime: -1, createTime: -1 })
     }
     update (groupId, group) {
-      return app.model.group.findOneAndUpdate({
+      return app.model.Group.findOneAndUpdate({
         _id: groupId,
         manager: this.ctx.authUser._id
       }, Object.assign(group, { modifiedTime: Date.now() }), { new: true })
     }
     updateTime (groupId) {
       // 此方法允许异步执行
-      return app.model.group.update({ _id: groupId }, { modifiedTime: Date.now() }, { new: true }).exec()
+      return app.model.Group.update({ _id: groupId }, { modifiedTime: Date.now() }, { new: true }).exec()
     }
     create (group) {
       const authId = this.ctx.authUser._id
@@ -57,10 +57,10 @@ module.exports = app => {
         creator: authId,
         manager: authId
       }
-      return app.model.group(_group).save()
+      return app.model.Group(_group).save()
     }
     getUserGroups (user, rights) {
-      return app.model.group.find({
+      return app.model.Group.find({
         [rights]: user,
         isDeleted: false
       }).sort({
@@ -68,13 +68,13 @@ module.exports = app => {
       })
     }
     getById (groupId) {
-      return app.model.group.findOne({
+      return app.model.Group.findOne({
         _id: groupId
       })
     }
     * delete (groupId) {
       const group = yield this.getById(groupId)
-      return app.model.group.findOneAndUpdate({
+      return app.model.Group.findOneAndUpdate({
         _id: groupId,
         manager: this.ctx.authUser._id
       }, {
@@ -90,7 +90,7 @@ module.exports = app => {
       return this.getUserGroups(null, 'manager')
     }
     claim (groupId) {
-      return app.model.group.findOneAndUpdate({
+      return app.model.Group.findOneAndUpdate({
         _id: groupId,
         manager: null
       }, {

--- a/server/app/service/stat.js
+++ b/server/app/service/stat.js
@@ -4,7 +4,7 @@ module.exports = app => {
   class Stat extends app.Service {
     // 保存数据方法异步执行
     saveApiStat (apiId, behavior, result) {
-      return app.model.apiStat({
+      return app.model.ApiStat({
         apiId,
         behavior,
         result
@@ -17,7 +17,7 @@ module.exports = app => {
       })
     }
     getMockStat (start, end) {
-      return app.model.apiStat.aggregate([
+      return app.model.ApiStat.aggregate([
         {
           $match: {
             behavior: API_BEHAVIOR_MOCK,

--- a/server/app/service/user.js
+++ b/server/app/service/user.js
@@ -2,24 +2,24 @@ const md5 = require('blueimp-md5')
 module.exports = app => {
   class UserService extends app.Service {
     * create (user) {
-      return (yield app.model.user({
+      return (yield app.model.User({
         email: user.email,
         password: md5(user.password, this.config.md5Key),
         name: user.name
       }).save()).toObject()
     }
     getByEmail (email) {
-      return app.model.user.findOne({
+      return app.model.User.findOne({
         email
       }).lean()
     }
     getById (id) {
-      return app.model.user.findOne({
+      return app.model.User.findOne({
         _id: id
       })
     }
     getByIds (ids) {
-      return app.model.user.find({
+      return app.model.User.find({
         _id: {
           $in: ids
         }
@@ -27,7 +27,7 @@ module.exports = app => {
     }
     find (q) {
       const reg = new RegExp(`.*${q}.*`, 'i')
-      return app.model.user.find({
+      return app.model.User.find({
         isDeleted: false,
         $or: [
           { name: reg },
@@ -36,7 +36,7 @@ module.exports = app => {
       })
     }
     updatePassword (email, password) {
-      return app.model.user.findOneAndUpdate({
+      return app.model.User.findOneAndUpdate({
         email
       }, {
         password: md5(password, this.config.md5Key),
@@ -44,7 +44,7 @@ module.exports = app => {
       }, { new: true }).lean()
     }
     updatePasswordByOldPassword (oldPassword, newPassword) {
-      return app.model.user.findOneAndUpdate({
+      return app.model.User.findOneAndUpdate({
         _id: this.ctx.authUser._id,
         password: md5(oldPassword, this.config.md5Key)
       }, {
@@ -54,7 +54,7 @@ module.exports = app => {
     }
     update (user) {
       const authId = this.ctx.authUser._id
-      return app.model.user.findOneAndUpdate({
+      return app.model.User.findOneAndUpdate({
         _id: authId
       }, {
         name: user.name,

--- a/server/config/plugin.js
+++ b/server/config/plugin.js
@@ -1,9 +1,16 @@
 
-// had enabled by egg
-// exports.static = true;
-exports['egg-cors'] = true
-exports['egg-mongoose'] = true
 exports.security = false
+
+exports.cors = {
+  enable: true,
+  package: 'egg-cors'
+}
+
+exports.mongoose = {
+  enable: true,
+  package: 'egg-mongoose'
+}
+
 exports.validate = {
   package: 'egg-validate'
 }

--- a/server/package.json
+++ b/server/package.json
@@ -4,26 +4,27 @@
   "description": "api-mocker-server",
   "private": true,
   "dependencies": {
-    "blueimp-md5": "2.7.0",
-    "egg": "1.8.0",
-    "egg-cors": "1.0.0",
-    "egg-mongoose": "1.1.1",
-    "egg-redis": "1.0.1",
-    "egg-validate": "1.0.0",
-    "http-assert": "1.2.0",
-    "lru-cache": "4.1.1",
-    "mocker-dsl-core": "0.1.2",
-    "moment": "2.18.1",
-    "nodemailer": "4.0.1",
-    "path-to-regexp": "1.7.0",
-    "ramda": "0.23.0"
+    "egg": "^2.0.0",
+    "egg-cors": "^2.0.0",
+    "egg-mongoose": "^2.1.1",
+    "egg-validate": "^1.0.0",
+    "blueimp-md5": "^2.10.0",
+    "http-assert": "^1.3.0",
+    "lru-cache": "^4.1.1",
+    "mocker-dsl-core": "^0.1.2",
+    "moment": "^2.19.3",
+    "mongoose": "^4.13.5",
+    "nodemailer": "^4.4.0",
+    "path-to-regexp": "^2.1.0",
+    "ramda": "^0.25.0"
   },
   "devDependencies": {
-    "autod": "^2.7.1",
-    "egg-bin": "^3.1.0",
-    "egg-ci": "^1.5.0",
-    "egg-mock": "^3.2.0",
-    "eslint": "^3.18.0",
+    "autod": "^3.0.1",
+    "autod-egg": "^1.0.0",
+    "egg-bin": "^4.3.6",
+    "egg-ci": "^1.8.0",
+    "egg-mock": "^3.13.1",
+    "eslint": "^4.12.1",
     "eslint-config-standard": "10.2.1",
     "eslint-plugin-import": "2.7.0",
     "eslint-plugin-node": "5.1.1",
@@ -31,10 +32,10 @@
     "eslint-plugin-standard": "3.0.1",
     "pm2": "2.4.2",
     "supertest": "^3.0.0",
-    "webstorm-disable-index": "^1.1.2"
+    "webstorm-disable-index": "^1.2.0"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "start": "node index.js",
@@ -49,11 +50,11 @@
     "autod": "autod"
   },
   "ci": {
-    "version": "6"
+    "version": "8"
   },
   "repository": {
     "type": "git",
-    "url": ""
+    "url": "git@github.com:DXY-F2E/api-mocker.git"
   },
   "author": "zhangfx",
   "license": "GPL-3.0"


### PR DESCRIPTION
## egg 升级为 2.0
- https://eggjs.org/zh-cn/migration.html
- 由于不知道是否能升级为 node8，所以没有修改 yield -> await
- egg 相关插件改为 `^` 引入，close https://github.com/DXY-F2E/api-mocker/issues/18
- 修正 plugin.js 等的一些不正确的引入
- 单元测试好像之前就是有问题的，所以没跑 

## 插件升级
升级 egg 2.0 基本上是无痛的，一行代码修改依赖即可。

但由于 `egg-mongoose` 这个插件很早前 BREAK 过，所以对应的代码要改下：
- model 声明的入参是 app，而不是 mongoose
- 调用 model 的首字母是大写
- https://github.com/eggjs/egg-mongoose/pull/7
